### PR TITLE
Add NBTAPI support and exclusion tag functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
       <version>1.18.30</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>de.tr7zw</groupId>
+      <artifactId>item-nbt-api</artifactId>
+      <version>2.15.1</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -99,6 +105,13 @@
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.30</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>
@@ -126,6 +139,10 @@
                 <relocation>
                   <pattern>org.bstats</pattern>
                   <shadedPattern>dev.demeng.ultrarepair.shaded.bstats</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>de.tr7zw.changeme.nbtapi</pattern>
+                  <shadedPattern>dev.demeng.ultrarepair.shaded.nbtapi</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/src/main/java/dev/demeng/ultrarepair/UltraRepair.java
+++ b/src/main/java/dev/demeng/ultrarepair/UltraRepair.java
@@ -84,6 +84,12 @@ public final class UltraRepair extends BasePlugin {
     getLogger().info("Checking for updates...");
     checkUpdates();
 
+    if(this.getServer().getPluginManager().isPluginEnabled("NBTAPI")) {
+      getLogger().info("NBTAPI detected, enabling support.");
+    } else {
+      getLogger().warning("NBTAPI not found, some features may not work.");
+    }
+
     Text.console("&aUltraRepair v" + Common.getVersion()
         + " by Demeng has been enabled.");
   }

--- a/src/main/java/dev/demeng/ultrarepair/command/RepairCmd.java
+++ b/src/main/java/dev/demeng/ultrarepair/command/RepairCmd.java
@@ -41,7 +41,7 @@ public class RepairCmd {
 
     p.closeInventory();
 
-    final ItemStack stack = p.getInventory().getItemInHand();
+    final ItemStack stack = p.getInventory().getItemInMainHand();
 
     if (!i.getRepairManager().isRepairable(stack)) {
       Text.tell(p, i.getMessages().getString("invalid-item"));

--- a/src/main/java/dev/demeng/ultrarepair/command/UltraRepairCmd.java
+++ b/src/main/java/dev/demeng/ultrarepair/command/UltraRepairCmd.java
@@ -1,12 +1,16 @@
 package dev.demeng.ultrarepair.command;
 
+import de.tr7zw.changeme.nbtapi.NBT;
 import dev.demeng.pluginbase.Common;
 import dev.demeng.pluginbase.text.Text;
 import dev.demeng.ultrarepair.UltraRepair;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import revxrsal.commands.annotation.Command;
 import revxrsal.commands.annotation.DefaultFor;
 import revxrsal.commands.annotation.Subcommand;
@@ -41,5 +45,53 @@ public class UltraRepairCmd {
     i.getRepairManager().reload();
 
     return i.getMessages().getString("reloaded");
+  }
+
+  @Subcommand("excludeitem")
+  @CommandPermission("ultrarepair.excludeitem")
+  public void runExcludeItem(CommandSender sender) {
+
+    if (!(sender instanceof Player)) {
+      Text.coloredTell(sender, "&cThis command can only be used by players.");
+      return;
+    }
+
+    Player player = (Player) sender;
+    ItemStack item = player.getInventory().getItemInMainHand();
+
+    if (item == null || item.getType() == Material.AIR) {
+      Text.coloredTell(player, "&cYou must be holding an item to exclude it from repair.");
+      return;
+    }
+
+    try {
+      // Check if NBT-API is available
+      if (!i.getServer().getPluginManager().isPluginEnabled("NBTAPI")) {
+        Text.coloredTell(player, "&cNBT-API is not available. This feature requires NBT-API to be installed.");
+        return;
+      }
+
+      // Check if item already has the exclude tag
+      boolean alreadyExcluded = NBT.get(item, (nbt) -> {
+        return nbt.hasTag("ultrarepair:exclude");
+      });
+
+      if (alreadyExcluded) {
+        Text.coloredTell(player, "&eThis item is already excluded from repair.");
+        return;
+      }
+
+      // Add the exclude tag
+      NBT.modify(item, nbt -> {
+        nbt.setBoolean("ultrarepair:exclude", true);
+      });
+
+      Text.coloredTell(player, "&aSuccessfully added exclusion tag to the item!");
+      Text.coloredTell(player, "&7This item will now be ignored by repair commands.");
+
+    } catch (Exception e) {
+      Text.coloredTell(player, "&cFailed to add exclusion tag to the item. Please check console for errors.");
+      i.getLogger().warning("Failed to add NBT exclusion tag: " + e.getMessage());
+    }
   }
 }

--- a/src/main/java/dev/demeng/ultrarepair/manager/RepairManager.java
+++ b/src/main/java/dev/demeng/ultrarepair/manager/RepairManager.java
@@ -1,5 +1,7 @@
 package dev.demeng.ultrarepair.manager;
 
+import de.tr7zw.changeme.nbtapi.NBT;
+import de.tr7zw.changeme.nbtapi.NBTItem;
 import dev.demeng.pluginbase.Common;
 import dev.demeng.pluginbase.Schedulers;
 import dev.demeng.pluginbase.Services;
@@ -67,13 +69,46 @@ public class RepairManager {
   }
 
   public boolean isRepairable(ItemStack stack) {
-    return stack != null
-        && stack.getType() != Material.AIR
-        && (!Common.isServerVersionAtLeast(13) || !stack.getType().isAir())
-        && !stack.getType().isBlock()
-        && !stack.getType().isEdible()
-        && stack.getType().getMaxDurability() > 0
-        && stack.getDurability() != 0;
+    if(i.getServer().getPluginManager().isPluginEnabled("NBTAPI")) {
+      return stack != null
+              && stack.getType() != Material.AIR
+              && (!Common.isServerVersionAtLeast(13) || !stack.getType().isAir())
+              && !stack.getType().isBlock()
+              && !stack.getType().isEdible()
+              && stack.getType().getMaxDurability() > 0
+              && stack.getDurability() != 0
+              && !hasNoRepairTag(stack);
+    } else {
+      return stack != null
+              && stack.getType() != Material.AIR
+              && (!Common.isServerVersionAtLeast(13) || !stack.getType().isAir())
+              && !stack.getType().isBlock()
+              && !stack.getType().isEdible()
+              && stack.getType().getMaxDurability() > 0
+              && stack.getDurability() != 0;
+    }
+  }
+
+  /**
+   * Checks if an item has the 'ultrarepair:exclude' NBT tag.
+   *
+   * @param stack the item to check
+   * @return true if the item has the 'ultrarepair:exclude' NBT tag, false otherwise
+   */
+  private boolean hasNoRepairTag(ItemStack stack) {
+    if (stack == null) {
+      return false;
+    }
+
+    try {
+      // Use NBT.get to check for the tag with explicit return type
+      return NBT.get(stack, (nbt) -> {
+        return nbt.hasTag("ultrarepair:exclude");
+      });
+    } catch (Exception e) {
+      // If NBT-API fails, fallback to false (allow repair)
+      return false;
+    }
   }
 
   public boolean hasAnyRepairable(Player p) {


### PR DESCRIPTION
Items can now be excluded from repair using NBT tags

How it works:

1. Hold any item and run /ur excludeitem
2. Item gets tagged with ultrarepair:exclude NBT
3. Both /repair hand and /repair all will ignore tagged items
4. Clean error messages and validation included
5. Technical notes:

Uses NBT.get() and NBT.modify() methods from NBT-API
Fallback when NBT-API isn't installed - not breaking the plugin 
Follows existing command patterns and permissions (ultrarepair.excludeitem)