### PR TITLE
Improvements to exclusion and cost multipliers 

### DIFF
--- a/src/main/java/dev/demeng/ultrarepair/command/RepairCmd.java
+++ b/src/main/java/dev/demeng/ultrarepair/command/RepairCmd.java
@@ -136,7 +136,14 @@ public class RepairCmd {
       return;
     }
 
-    i.getRepairManager().repairAll(p);
-    Text.tell(p, i.getMessages().getString("repaired-all"));
+    final boolean hadExcluded = i.getRepairManager().repairAll(p);
+    String msg = i.getMessages().getString("repaired-all");
+    if (hadExcluded) {
+      final String partial = i.getMessages().getString("repaired-all-partial");
+      if (partial != null && !partial.isEmpty()) {
+        msg = partial;
+      }
+    }
+    Text.tell(p, msg);
   }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -47,6 +47,10 @@ repaired-hand: "&7The item in your hand has been repaired."
 # When the player's inventory has been successfully repaired.
 repaired-all: "&7Your inventory has been repaired."
 
+# When /repair all runs but some damaged items were excluded by their settings.
+# Tip: You can inform players how to repair those items (e.g., with special tokens) if applicable.
+repaired-all-partial: "&7Your inventory has been repaired. &eHowever, some items were excluded from repair due to their settings."
+
 # If the item cannot be excluded from repair (not repairable).
 exclude-invalid: "&7You cannot exclude this item from repair."
 

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -55,3 +55,23 @@ cost-exceptions:
       DURABILITY: 1
       # Sharpness III
       DAMAGE_ALL: 3
+
+# Exclude certain items from being repaired based on Material + CustomModelData.
+# This is useful when you cannot add the ultrarepair:exclude NBT tag to those items.
+# Format:
+# exclude:
+#   MATERIAL_NAME:
+#     customdata:
+#       - 15155
+#       - 26262
+#       - 15152
+# Example configuration:
+exclude:
+  PAPER:
+    customdata:
+      - 15155
+      - 26262
+  STICK:
+    customdata:
+      - 6969
+      - 5959


### PR DESCRIPTION
* Added a new configuration section (`exclude`) in `settings.yml` to specify which items (by `Material` and `CustomModelData`) should be excluded from repair

* Modified the `repairAll` to detect if any damaged items were excluded from repair. If so, a different message is sent to the player, informing them about the partial repair. 

* Improved the cost exception logic by introducing a new `isBasedOn` method, which more flexibly matches items for cost overrides, considering display name, lore, enchants, and custom model data. 